### PR TITLE
Remove confusing "user" option and user "namespace" instead.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /blackbeard
 /vendor/
 /.go
+/.idea/

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -11,8 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var namespace string
-
 // applyCmd represents the apply command
 var applyCmd = &cobra.Command{
 	Use:   "apply",
@@ -34,26 +32,25 @@ This command will update the Kubernetes files and apply this configuration to th
 
 func init() {
 	RootCmd.AddCommand(applyCmd)
-	applyCmd.Flags().StringVarP(&namespace, "username", "u", "", "The username for the environment")
-	applyCmd.Flags().StringVarP(&usr, "namespace", "n", "", "Same as username")
+	applyCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "The namespace where to apply configuration")
 
 }
 
 func runApply(namespace string) error {
 
 	if namespace == "" {
-		return errors.New("You must specified a username")
+		return errors.New("you must specified a namespace for the testing env using the --namespace flag")
 	}
 
-	files := files.NewClient(templatePath, configPath, inventoryPath, defaultsPath)
+	f := files.NewClient(templatePath, configPath, inventoryPath, defaultsPath)
 
-	inv, err := files.InventoryService().Get(namespace)
+	inv, err := f.InventoryService().Get(namespace)
 
 	if err != nil {
 		return err
 	}
 
-	err = files.ConfigService().Apply(inv)
+	err = f.ConfigService().Apply(inv)
 	if err != nil {
 		return err
 	}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -15,8 +15,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var usr string
-
 // createCmd represents the create command
 var createCmd = &cobra.Command{
 	Use:   "create",
@@ -28,7 +26,7 @@ Feel free to edit this file before applying changes.
 `,
 
 	Run: func(cmd *cobra.Command, args []string) {
-		err := runCreate(usr, inventoryPath)
+		err := runCreate(namespace, inventoryPath)
 		if err != nil {
 			fmt.Println(err.Error())
 			os.Exit(-1)
@@ -38,27 +36,25 @@ Feel free to edit this file before applying changes.
 
 func init() {
 	RootCmd.AddCommand(createCmd)
-
-	createCmd.Flags().StringVarP(&usr, "username", "u", "", "The username for the environement")
-	createCmd.Flags().StringVarP(&usr, "namespace", "n", "", "Same as username")
+	createCmd.Flags().StringVarP(&namespace, "namespace", "n", "", "The namespace where to apply configuration")
 }
 
-func runCreate(usr, inventoryPath string) error {
+func runCreate(namespace, inventoryPath string) error {
 
-	if usr == "" {
-		return errors.New("You must specified a username for the testing env using the --username flag")
+	if namespace == "" {
+		return errors.New("you must specified a namespace for the testing env using the --namespace flag")
 	}
 
-	files := files.NewClient(templatePath, configPath, inventoryPath, defaultsPath)
+	f := files.NewClient(templatePath, configPath, inventoryPath, defaultsPath)
 
-	inv, err := files.InventoryService().Create(usr)
+	inv, err := f.InventoryService().Create(namespace)
 
 	if err != nil {
 		log.Println(err.Error())
 		log.Println("continue")
 	}
 
-	err = files.ConfigService().Apply(inv)
+	err = f.ConfigService().Apply(inv)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,7 @@ var templatePath string
 var configPath string
 var inventoryPath string
 var defaultsPath string
+var namespace string
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{


### PR DESCRIPTION
This is done because a namespace is not necessary created for a user. It
could also be created for automated tests.