### PR TITLE
Feat/add namespace status routes

### DIFF
--- a/pkg/http/resource_handler.go
+++ b/pkg/http/resource_handler.go
@@ -31,6 +31,7 @@ func (h *Handler) ListServices(c *gin.Context) {
 	c.JSON(http.StatusOK, services)
 }
 
+//GetStatus returns the namespace status (ready or not) for a given namespace
 func (h *Handler) GetStatus(c *gin.Context) {
 
 	_, err := h.config.InventoryService().Get(c.Params.ByName("namespace"))
@@ -58,6 +59,7 @@ func (h *Handler) GetStatus(c *gin.Context) {
 	})
 }
 
+//GetStatuses returns an array of namespaces and their associated status
 func (h *Handler) GetStatuses(c *gin.Context) {
 
 	invs, _ := h.config.InventoryService().List()

--- a/pkg/http/resource_handler.go
+++ b/pkg/http/resource_handler.go
@@ -30,3 +30,58 @@ func (h *Handler) ListServices(c *gin.Context) {
 
 	c.JSON(http.StatusOK, services)
 }
+
+func (h *Handler) GetStatus(c *gin.Context) {
+
+	_, err := h.config.InventoryService().Get(c.Params.ByName("namespace"))
+
+	if err != nil {
+		if notFound, ok := err.(files.ErrorInventoryNotFound); ok {
+			c.JSON(http.StatusNotFound, gin.H{"error": notFound.Error()})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	status, err := h.kubernetes.ResourceService().GetNamespaceStatus(c.Params.ByName("namespace"))
+
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, struct {
+		Status string `json:"status"`
+	}{
+		Status: status,
+	})
+}
+
+func (h *Handler) GetStatuses(c *gin.Context) {
+
+	invs, _ := h.config.InventoryService().List()
+
+	var status []struct {
+		Namespace string `json:"namespace"`
+		Status    string `json:"status"`
+	}
+
+	for _, i := range invs {
+		s, err := h.kubernetes.ResourceService().GetNamespaceStatus(i.Namespace)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		status = append(status, struct {
+			Namespace string `json:"namespace"`
+			Status    string `json:"status"`
+		}{
+			Namespace: i.Namespace,
+			Status:    s,
+		})
+	}
+
+	c.JSON(http.StatusOK, status)
+}

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -34,7 +34,7 @@ func NewHandler(c blackbeard.ConfigClient, kubecli blackbeard.KubectlClient, k b
 	h.engine.GET("/inventories/:namespace/status", h.GetStatus)
 	h.engine.GET("/inventories/:namespace/services", h.ListServices)
 	h.engine.GET("/inventories", h.List)
-	h.engine.GET("/inventories", h.GetStatuses)
+	//h.engine.GET("/inventories/status", h.GetStatuses)
 	h.engine.GET("/defaults", h.GetDefaults)
 	h.engine.PUT("/inventories/:namespace", h.Update)
 	h.engine.DELETE("/inventories/:namespace", h.Delete)

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -31,8 +31,10 @@ func NewHandler(c blackbeard.ConfigClient, kubecli blackbeard.KubectlClient, k b
 
 	h.engine.POST("/inventories", h.Create)
 	h.engine.GET("/inventories/:namespace", h.Get)
+	h.engine.GET("/inventories/:namespace/status", h.GetStatus)
 	h.engine.GET("/inventories/:namespace/services", h.ListServices)
 	h.engine.GET("/inventories", h.List)
+	h.engine.GET("/inventories", h.GetStatuses)
 	h.engine.GET("/defaults", h.GetDefaults)
 	h.engine.PUT("/inventories/:namespace", h.Update)
 	h.engine.DELETE("/inventories/:namespace", h.Delete)

--- a/pkg/kubectl/namespace_configuration_service.go
+++ b/pkg/kubectl/namespace_configuration_service.go
@@ -24,17 +24,6 @@ type NamespaceConfigurationService struct {
 //Ensure that NamespaceService implements the interface
 var _ blackbeard.NamespaceConfigurationService = (*NamespaceConfigurationService)(nil)
 
-//Create create a namespace
-//func (ns *NamespaceConfigurationService) Create(inv blackbeard.Inventory) error {
-//
-//	err := execute(fmt.Sprintf("kubectl create namespace %s", inv.Namespace), timeout)
-//	if err != nil {
-//		return fmt.Errorf("the namespace %s could not be created because either the namespace already exist or the command timed out : %v", inv.Namespace, err)
-//	}
-//
-//	return nil
-//}
-
 //Apply load configuration files into kubernetes
 func (ns *NamespaceConfigurationService) Apply(inv blackbeard.Inventory) error {
 

--- a/swagger.json
+++ b/swagger.json
@@ -139,6 +139,47 @@
         }
       }
     },
+    "/inventories/{namespace}/status": {
+      "get": {
+        "description": "Read the namespace status : either ready or not ready",
+        "operationId": "get-inventory-status",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "Namespace name",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The status",
+            "schema": {
+              "$ref": "#/definitions/blackbeard.Inventory.Status"
+            }
+          },
+          "404": {
+            "description": "Can not find the namespace/inventory",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "500": {
+            "description": "Something went wrong when reading the inventory",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
     "/inventories": {
       "post": {
         "description": "Create an inventory for the given namespace. This will also create the inventory file and the associated namespace.",
@@ -295,14 +336,39 @@
         }
       }
     },
+    "blackbeard.Inventory.Status": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string"
+        }
+      }
+    },
     "blackbeard.Service": {
       "type": "object",
       "properties": {
-        "Namespace": {
+        "name": {
           "type": "string"
         },
-        "Values": {
-          "type": "object"
+        "port": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/service.Port"
+          }
+        },
+        "addr": {
+          "type": "string"
+        }
+      }
+    },
+    "service.Port": {
+      "type" : "object",
+      "properties": {
+        "port": {
+          "type": "integer"
+        },
+        "exposedPort": {
+          "type": "integer"
         }
       }
     },


### PR DESCRIPTION
This feature if for monitoring purpose. We expose 2 new API endpoint
    letting the client know :
 1 - What is the current status of a given namespace by calling the
    route /inventories/:namespace/status