### PR TITLE
fix(defunct-process): Prevent defunct zombie process when watcher restart

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,11 +1,10 @@
 package cmd
 
 import (
-	"github.com/Meetic/blackbeard/pkg/websocket"
-
 	"github.com/spf13/cobra"
 
 	"github.com/Meetic/blackbeard/pkg/http"
+	"github.com/Meetic/blackbeard/pkg/websocket"
 )
 
 // serveCmd represents the serve command

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -5,9 +5,10 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/Meetic/blackbeard/pkg/api"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
+
+	"github.com/Meetic/blackbeard/pkg/api"
 )
 
 // Handler actually handle http requests.
@@ -80,5 +81,13 @@ func NewServer(h *Handler) *Server {
 
 // Serve launch the webserver
 func (s *Server) Serve(port int) {
+
+	go func() {
+		err := s.handler.api.Namespaces().WatchNamespaces()
+		if err != nil {
+			log.Println(fmt.Sprintf("error while trying to watch namespace : %s", err.Error()))
+		}
+	}()
+
 	s.handler.Engine().Run(fmt.Sprintf(":%d", port))
 }

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -85,7 +85,7 @@ func (ns *namespaceRepository) List() ([]resource.Namespace, error) {
 	return namespaces, nil
 }
 
-func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter) error {
+func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter, restarter chan<- int) error {
 
 	watcher, err := ns.kubernetes.CoreV1().Namespaces().Watch(metav1.ListOptions{})
 
@@ -97,7 +97,7 @@ func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter) error {
 	defer func() {
 		watcher.Stop()
 		log.Printf("[WATCHER] restart watcher due to connection close")
-		ns.WatchPhase(emit) // restart watcher if stop
+		restarter <- 1 // restart watcher if stop
 	}()
 
 	for event := range watcher.ResultChan() {

--- a/pkg/kubernetes/namespace.go
+++ b/pkg/kubernetes/namespace.go
@@ -85,7 +85,7 @@ func (ns *namespaceRepository) List() ([]resource.Namespace, error) {
 	return namespaces, nil
 }
 
-func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter, restarter chan<- int) error {
+func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter) error {
 
 	watcher, err := ns.kubernetes.CoreV1().Namespaces().Watch(metav1.ListOptions{})
 
@@ -93,12 +93,6 @@ func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter, restarter 
 		log.Printf("[WATCHER] %s", err.Error())
 		return err
 	}
-
-	defer func() {
-		watcher.Stop()
-		log.Printf("[WATCHER] restart watcher due to connection close")
-		restarter <- 1 // restart watcher if stop
-	}()
 
 	for event := range watcher.ResultChan() {
 		n := event.Object.(*v1.Namespace)

--- a/pkg/mock/namespace.go
+++ b/pkg/mock/namespace.go
@@ -37,7 +37,7 @@ func (ns *namespaceRepository) Delete(namespace string) error {
 	return nil
 }
 
-func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter) error {
+func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter, restarter chan<- int) error {
 	return nil
 }
 

--- a/pkg/mock/namespace.go
+++ b/pkg/mock/namespace.go
@@ -37,7 +37,7 @@ func (ns *namespaceRepository) Delete(namespace string) error {
 	return nil
 }
 
-func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter, restarter chan<- int) error {
+func (ns *namespaceRepository) WatchPhase(emit resource.EventEmitter) error {
 	return nil
 }
 

--- a/pkg/resource/namespace.go
+++ b/pkg/resource/namespace.go
@@ -25,6 +25,7 @@ type NamespaceService interface {
 	AddListener(name string)
 	RemoveListener(name string) error
 	Emit(event NamespaceEvent)
+	WatchNamespaces() error
 }
 
 // NamespaceRepository defined the way namespace area actually managed.
@@ -34,7 +35,7 @@ type NamespaceRepository interface {
 	ApplyConfig(namespace string, configPath string) error
 	Delete(namespace string) error
 	List() ([]Namespace, error)
-	WatchPhase(emit EventEmitter) error
+	WatchPhase(emit EventEmitter, restarter chan<- int) error
 }
 
 type namespaceService struct {
@@ -67,8 +68,6 @@ func NewNamespaceService(namespaces NamespaceRepository, pods PodRepository) Nam
 		namespaces: namespaces,
 		pods:       pods,
 	}
-
-	ns.WatchNamespaces()
 
 	return ns
 }
@@ -105,8 +104,16 @@ func (ns *namespaceService) Emit(event NamespaceEvent) {
 
 // WatchNamespaces create a watcher on namespace events from kubernetes cluster and send result over received channel
 func (ns *namespaceService) WatchNamespaces() error {
-	go ns.namespaces.WatchPhase(ns.Emit)
 	go ns.watchStatus()
+
+	// notify parent process when watch phase crash using channel
+	restarter := make(chan int, 1)
+	restarter <- 1 // init watch phase by putting something into the channel
+	defer close(restarter)
+
+	for range restarter {
+		go ns.namespaces.WatchPhase(ns.Emit, restarter)
+	}
 
 	return nil
 }

--- a/pkg/resource/namespace.go
+++ b/pkg/resource/namespace.go
@@ -35,7 +35,7 @@ type NamespaceRepository interface {
 	ApplyConfig(namespace string, configPath string) error
 	Delete(namespace string) error
 	List() ([]Namespace, error)
-	WatchPhase(emit EventEmitter, restarter chan<- int) error
+	WatchPhase(emit EventEmitter) error
 }
 
 type namespaceService struct {
@@ -106,14 +106,12 @@ func (ns *namespaceService) Emit(event NamespaceEvent) {
 func (ns *namespaceService) WatchNamespaces() error {
 	go ns.watchStatus()
 
-	// notify parent process when watch phase crash using channel
-	restarter := make(chan int, 1)
-	restarter <- 1 // init watch phase by putting something into the channel
-	defer close(restarter)
-
-	for range restarter {
-		go ns.namespaces.WatchPhase(ns.Emit, restarter)
-	}
+	go func() {
+		for {
+			ns.namespaces.WatchPhase(ns.Emit)
+			log.Printf("[WATCHER] restart watcher due to connection close")
+		}
+	}()
 
 	return nil
 }

--- a/pkg/resource/namespace_test.go
+++ b/pkg/resource/namespace_test.go
@@ -71,3 +71,30 @@ func TestRemoveListener(t *testing.T) {
 
 	assert.Nil(t, chNil)
 }
+
+func TestDelete(t *testing.T) {
+	err := namespaces.Delete("foobar")
+
+	assert.Nil(t, err)
+}
+
+func TestApplyConfig(t *testing.T) {
+	err := namespaces.ApplyConfig("foobar", "config")
+
+	assert.Nil(t, err)
+}
+
+func TestList(t *testing.T) {
+	namespaces, err := namespaces.List()
+
+	expectedNamespaces := []resource.Namespace{
+		{
+			Name:   "test",
+			Phase:  "active",
+			Status: 100,
+		},
+	}
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedNamespaces, namespaces)
+}


### PR DESCRIPTION
Fix zombie process

```
\_ /bin/sh -c blackbeard serve
root      15174  0.0  0.2 205844 21624 ?        Sl   janv.25   1:35  |   |       \_ blackbeard serve
root      15246  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      15406  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      15575  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      16780  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      27739  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      30541  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      33021  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      35204  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      44488  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      44499  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      44516  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      44527  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      44536  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      45792  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
root      50803  0.0  0.0      0     0 ?        Z    janv.25   0:00  |   |           \_ [sh] <defunct>
```